### PR TITLE
Fixed argument value bleed into the next empty argument

### DIFF
--- a/psCommandService.js
+++ b/psCommandService.js
@@ -304,7 +304,7 @@ PSCommandService.prototype._generateCommand = function(commandConfig, argument2V
 
                         var passedArgValue = passedArgValues[i];
 
-                        var valueToSet;
+                        var valueToSet = "";
 
                         if (passedArgValue && passedArgValue != 'undefined') {
                             valueToSet = passedArgValue;

--- a/test/unit.js
+++ b/test/unit.js
@@ -645,7 +645,7 @@ describe("test PSCommandService w/ o365CommandRegistry", function () {
       assert.fail(e);
     } finally {
       await psCommandService.execute("removeItem", {
-        Path: "./test.txt"
+        Path: "./test.txt",
        });    
       setTimeout(() => {
         statefulProcessCommandProxy.shutdown();

--- a/test/unit.js
+++ b/test/unit.js
@@ -84,6 +84,29 @@ const commandRegistry = {
       type: "text",
     },
   },
+  setContent: {
+    command: "Set-Content {{{arguments}}}",
+    arguments: {
+      'Path': {},
+      'Value': {},
+      'Filter': {},
+    },
+  },
+  getContent: {
+    command: "Get-Content {{{arguments}}}",
+    arguments: {
+      'Path': {},
+    },
+    return: {
+      type: "text",
+    },
+  },
+  removeItem: {
+    command: "Remove-Item {{{arguments}}}",
+    arguments: {
+      'Path': {},
+    },
+  },
 };
 
 
@@ -578,6 +601,55 @@ describe("test PSCommandService w/ o365CommandRegistry", function () {
         statefulProcessCommandProxy.shutdown();
       }, 5000);
       throw e;
+    }
+  });
+  it("Should test value bleading", async function () {
+    this.timeout(10000);
+    const statefulProcessCommandProxy = new StatefulProcessCommandProxy({
+      name: "Powershell pool",
+      max: 1,
+      min: 1,
+      idleTimeoutMS: 30000,
+
+      logFunction: logFunction,
+      processCommand: "pwsh",
+      processArgs: ["-Command", "-"],
+      processRetainMaxCmdHistory: 30,
+      processCwd: null,
+      processEnvMap: null,
+      processUid: null,
+      processGid: null,
+      initCommands: initCommands,
+      validateFunction: (processProxy) => processProxy.isValid(),
+    });
+
+    const psCommandService = new PSCommandService(
+      statefulProcessCommandProxy,
+      commandRegistry,
+      myLogFunction
+    );
+    try {
+      const newResult = await psCommandService.execute("setContent", {
+        Path: "./test.txt",
+        Value: "Test",
+        Filter: ""
+      });
+      assert.equal(newResult.command.trim(), "Set-Content -Path './test.txt' -Value 'Test'");
+      assert.equal(newResult.stderr, "");
+      const getResult = await psCommandService.execute("getContent", {
+        Path: "./test.txt",
+      });
+      assert.equal(getResult.stderr, "");
+      assert.equal(getResult.stdout, "Test");
+    } catch (e) {
+      assert.fail(e);
+    } finally {
+      await psCommandService.execute("removeItem", {
+        Path: "./test.txt"
+       });    
+      setTimeout(() => {
+        statefulProcessCommandProxy.shutdown();
+      }, 5000);
     }
   });
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -603,7 +603,7 @@ describe("test PSCommandService w/ o365CommandRegistry", function () {
       throw e;
     }
   });
-  it("Should test value bleading", async function () {
+  it("Should test value bleeding", async function () {
     this.timeout(10000);
     const statefulProcessCommandProxy = new StatefulProcessCommandProxy({
       name: "Powershell pool",


### PR DESCRIPTION
When executing the command with an empty string argument  the generated PowerShell command incorrectly includes the value for the previous argument as value for the current one,


Expected Behavior:
When argument is an empty string (""), it should be omitted from the generated command
When argument is undefined, it should be omitted from the generated command
Only when argument has a meaningful value should it appear in the command

Actual Behavior:
Empty argument gets populated with the value of the previous argument.

Test Cases Demonstrating the Bug:
```
psCommandService.execute("setContent", {
        Path: "./test.txt",
        Value: "Test",
        Filter: ""
})
``` 
is expected to generate output:
`Set-Content -Path './test.txt' -Value 'Test'`

actual result:
`Set-Content -Path './test.txt' -Value 'Test' -Filter 'Test'`

Test has been updated to cover the fix for this scenario.