### PR TITLE
Added support for the empty arguments passed to the command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,48 @@ There is also option to run Docker based tests. You need to configure `environme
 
 Exchange online tests will be skipped if the connection is not available.
 
+### Empty Argument Values Support
+
+As of version 1.1.5, the module now supports passing empty string values to PowerShell command arguments when explicitly configured. This is useful for optional parameters that need to be passed as empty values rather than omitted entirely.
+
+To enable empty value support for a command argument, set the `empty` property to `true` in the argument configuration:
+
+```javascript
+const commandRegistry = {
+  'myCommand': {
+    command: "Get-Content {{{arguments}}}",
+    arguments: {
+      'Path': {},
+      'Filter': {
+        empty: true,  // Allow empty string values
+      },
+    },
+    return: {
+      type: "text",
+    }
+  }
+};
+```
+
+When `empty: true` is set, the argument will accept empty string values and include them in the generated PowerShell command:
+
+```javascript
+// This will generate: Get-Content -Path './test.txt' -Filter ''
+await psCommandService.execute("myCommand", {
+  Path: "./test.txt",
+  Filter: ""  // Empty string value is now allowed
+});
+```
+
+
 
 ### <a id="history"></a>History
 
 ```
+v1.1.5 - 2025-09-19
+    - Added support for empty argument values in commands via 'empty' property
+    - Fixed argument value bleed into the next empty argument
+
 v1.1.4 - 2024-11-22
     - Extended testing and fixed escaping reserved variables and special characters in commands
 
@@ -74,6 +112,7 @@ v1.1.3 - 2024-11-14
 
 v1.1.2 - 2022-07-06
     - Added support for usage of reserved powershell variables in commands [$null, $true, $false]
+
 
 v1.1.1 - 2020-12-07
     - Fixed bug import of custom commands if provided for certificate based auth

--- a/psCommandService.js
+++ b/psCommandService.js
@@ -282,6 +282,7 @@ PSCommandService.prototype._generateCommand = function(commandConfig, argument2V
                 if ((argument.hasOwnProperty('valued') ? argument.valued : true)) {
 
                     var isQuoted = (argument.hasOwnProperty('quoted') ? argument.quoted : true);
+                    var isEmpty = (argument.hasOwnProperty('empty') ? argument.empty : false);
                     var passedArgValues = argument2ValueMap[argumentName];
 
                     if (!(passedArgValues instanceof Array)) {
@@ -314,7 +315,7 @@ PSCommandService.prototype._generateCommand = function(commandConfig, argument2V
                         }
 
                         // append the value
-                        if (valueToSet && valueToSet.trim().length > 0) {
+                        if (valueToSet != null && valueToSet != undefined && (isEmpty || valueToSet.trim().length > 0)) {
 
                             // sanitize
                             valueToSet = this._sanitize(valueToSet,isQuoted);

--- a/psCommandService.js
+++ b/psCommandService.js
@@ -315,7 +315,7 @@ PSCommandService.prototype._generateCommand = function(commandConfig, argument2V
                         }
 
                         // append the value
-                        if (valueToSet != null && valueToSet != undefined && (isEmpty || valueToSet.trim().length > 0)) {
+                        if (valueToSet !== null && valueToSet !== undefined && (isEmpty || valueToSet.trim().length > 0)) {
 
                             // sanitize
                             valueToSet = this._sanitize(valueToSet,isQuoted);

--- a/test/unit.js
+++ b/test/unit.js
@@ -700,7 +700,7 @@ describe("test PSCommandService w/ o365CommandRegistry", function () {
     } finally {
       await psCommandService.execute("removeItem", {
         Path: "./test.txt",
-       });    
+       });
       setTimeout(() => {
         statefulProcessCommandProxy.shutdown();
       }, 5000);


### PR DESCRIPTION
This PR adds support for explicitly passing empty string values to PowerShell command arguments when configured to allow them. Previously, empty string arguments were filtered out and not included in generated commands. This enhancement provides more flexibility for PowerShell cmdlets that distinguish between omitted parameters and explicitly empty parameters.

The need has originated from the ability to remove the value set for certain properties this is the way to do it via Powershell.

Test coverage has been added to cover the addition.

Change is a nonbreaking change ensuring existing implementation will not break upon upgrade.

Example:

```
psCommandService.execute("setContent", {
        Path: "./test.txt",
        Value: "",
        Filter: "*.txt"
})
```

Currently generating:
`Set-Content -Path './test.txt' -Filter '*.txt'`

Desired output:
`Set-Content -Path './test.txt' -Value '' -Filter '*.txt'`

This is archived by marking argument `Filter` as `empty` in the commend definition.

```
  getContent: {
    command: "Get-Content {{{arguments}}}",
    arguments: {
      'Path': {},
      'Filter': {
        empty: true,
      },
    },
    return: {
      type: "text",
    },
  },
```


